### PR TITLE
Added Macau to alpha 3 dictionary

### DIFF
--- a/pycountry_convert/country_alpha3_to_country_alpha2.py
+++ b/pycountry_convert/country_alpha3_to_country_alpha2.py
@@ -138,6 +138,7 @@ COUNTRY_ALPHA3_TO_COUNTRY_ALPHA2 = {
     'LTU': 'LT',
     'LUX': 'LU',
     'LVA': 'LV',
+    'MAC': 'MO',
     'MAF': 'MF',
     'MAR': 'MA',
     'MCO': 'MC',


### PR DESCRIPTION
Added Macau to the alpha 3 dictionary.
It was, however, already present in the alpha2 dictionary